### PR TITLE
fix: avoid error when there is no shard iterator

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,5 +8,5 @@ root = true
 end_of_line = lf
 insert_final_newline = true
 charset = utf-8
-indent_style = tab
+indent_style = space
 indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -8,5 +8,5 @@ root = true
 end_of_line = lf
 insert_final_newline = true
 charset = utf-8
-indent_style = space
+indent_style = tab
 indent_size = 2

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "semantic-release": "^15.13.24"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=8.12.0"
   },
   "files": [
     "/bin",


### PR DESCRIPTION
Looks like when tailing data from a stream using the DynamoDB local (I haven't tested if this happen on _real_ stream), some shards aren't available (I don't know why) and it generates that error:

```
jeremy@falcon-heavy:~/Sites/github/lumigo-CLI$ ./bin/run tail-dynamodb -e http://localhost:8000 -n user_front -r localhost -p testing
checking DynamoDB table [user_front] in [localhost]
stream arn is: arn:aws:dynamodb:ddblocal:000000000000:table/user_front/stream/2019-10-07T14:26:15.536
checking DynamoDB stream [arn:aws:dynamodb:ddblocal:000000000000:table/user_front/stream/2019-10-07T14:26:15.536] in [localhost]
polling DynamoDB stream for table [user_front] (2 shards)...
press <any key> to stop
MissingRequiredParameter: Missing required key 'ShardIterator' in params
    at ParamValidator.fail (~/Sites/github/lumigo-CLI/node_modules/aws-sdk/lib/param_validator.js:50:37)
    at ParamValidator.validateStructure (~/Sites/github/lumigo-CLI/node_modules/aws-sdk/lib/param_validator.js:61:14)
    at ParamValidator.validateMember (~/Sites/github/lumigo-CLI/node_modules/aws-sdk/lib/param_validator.js:88:21)
    at ParamValidator.validate (~/Sites/github/lumigo-CLI/node_modules/aws-sdk/lib/param_validator.js:34:10)
    at Request.VALIDATE_PARAMETERS (~/Sites/github/lumigo-CLI/node_modules/aws-sdk/lib/event_listeners.js:126:42)
    at Request.callListeners (~/Sites/github/lumigo-CLI/node_modules/aws-sdk/lib/sequential_executor.js:106:20)
    at callNextListener (~/Sites/github/lumigo-CLI/node_modules/aws-sdk/lib/sequential_executor.js:96:12)
    at ~/Sites/github/lumigo-CLI/node_modules/aws-sdk/lib/event_listeners.js:86:9
    at finish (~/Sites/github/lumigo-CLI/node_modules/aws-sdk/lib/config.js:357:7)
    at ~/Sites/github/lumigo-CLI/node_modules/aws-sdk/lib/config.js:375:9
```

Checking if `iteratorResp.ShardIterator` is defined before trying to get records, fix the issue:

```
jeremy@falcon-heavy:~/Sites/github/lumigo-CLI$ ./bin/run tail-dynamodb -e http://localhost:8000 -n user_front -r localhost -p testing
checking DynamoDB table [user_front] in [localhost]
stream arn is: arn:aws:dynamodb:ddblocal:000000000000:table/user_front/stream/2019-10-07T14:26:15.536
checking DynamoDB stream [arn:aws:dynamodb:ddblocal:000000000000:table/user_front/stream/2019-10-07T14:26:15.536] in [localhost]
polling DynamoDB stream for table [user_front] (2 shards)...
press <any key> to stop
```