### PR TITLE
style: set linebreak-style to windows instead of unix

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,7 +11,7 @@
 	},
 	"rules": {
 		"indent": ["error", "tab"],
-		"linebreak-style": ["error", "unix"],
+		"linebreak-style": ["error", "windows"],
 		"quotes": ["error", "double", { "avoidEscape": true }],
 		"semi": ["error", "always"],
 		"no-console": 0


### PR DESCRIPTION
During code exploration I have found a lot of errors from eslint about linebreaks. It seems like everywhere is used windows linebreaks instead of unix.